### PR TITLE
MW-441 working on custom fields

### DIFF
--- a/tap_jira/schemas/changelogs.json
+++ b/tap_jira/schemas/changelogs.json
@@ -45,6 +45,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",
@@ -122,6 +128,12 @@
               "string"
             ]
           },
+          "tmpFromAccountId": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
           "from": {
             "type": [
               "null",
@@ -129,6 +141,12 @@
             ]
           },
           "fromString": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "tmpToAccountId": {
             "type": [
               "null",
               "string"

--- a/tap_jira/schemas/issue_comments.json
+++ b/tap_jira/schemas/issue_comments.json
@@ -141,6 +141,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",

--- a/tap_jira/schemas/issue_transitions.json
+++ b/tap_jira/schemas/issue_transitions.json
@@ -125,6 +125,18 @@
         "boolean"
       ]
     },
+    "isAvailable": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
+    "isLooped": {
+      "type": [
+        "null",
+        "boolean"
+      ]
+    },
     "isInitial": {
       "type": [
         "null",

--- a/tap_jira/schemas/issues.json
+++ b/tap_jira/schemas/issues.json
@@ -445,138 +445,21 @@
           ]
         },
 
-        "customfield_10000": {
-          "title": "development",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10001": {
-          "title": "team",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10002": {
-          "title": "organizations",
-          "__COMMENT": "not sure of data type, don't import yet",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10003": {
-          "title": "approvers",
-          "__COMMENT": "actually an array of users, don't import yet",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10004": {
-          "title": "impact",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10005": {
-          "title": "changetype",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10006": {
-          "title": "changerisk",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10007": {
-          "title": "changereason",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10008": {
-          "title": "actualstart",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10009": {
-          "title": "actualend",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10010": {
-          "title": "requesttype",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10011": {
-          "title": "epicname",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10012": {
-          "title": "epicstatus",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10013": {
-          "title": "epiccolor",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10014": {
+        "Epic Link": {
           "title": "epiclink",
           "type": [
             "null",
             "string"
           ]
         },
-        "customfield_10015": {
-          "title": "startdate",
+        "Story Points": {
+          "title": "storypoints",
           "type": [
             "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10016": {
-          "title": "storypointestimate",
-          "type": [
-            "null",
-            "string"
+            "number"
           ]
         },
-        "customfield_10017": {
-          "title": "issuecolor",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10018": {
+        "Parent Link": {
           "title": "parentlink",
           "type": [
             "null",
@@ -586,14 +469,14 @@
             ".+": {}
           }
         },
-        "customfield_10019": {
+        "Rank": {
           "title": "rank",
           "type": [
             "null",
             "string"
           ]
         },
-        "customfield_10020": {
+        "Sprint": {
           "title": "sprint",
           "type": [
             "null",
@@ -603,65 +486,15 @@
             "$ref": "sprint"
           }
         },
-        "customfield_10021": {
-          "title": "flagged",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10022": {
-          "title": "targetstart",
+        "_custom": {
+          "title": "othercustomfields",
           "type": [
             "null",
             "string"
           ],
-          "format": "date-time"
-        },
-        "customfield_10023": {
-          "title": "targetend",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-        "customfield_10024": {
-          "title": "dateoffirstresponse",
-          "type": [
-            "null",
-            "string"
-          ],
-          "format": "date-time"
-        },
-
-        "customfield_10025": {
-          "title": "timeinstatus",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10026": {
-          "title": "storypoints",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10027": {
-          "title": "uuid",
-          "type": [
-            "null",
-            "string"
-          ]
-        },
-        "customfield_10028": {
-          "title": "location",
-          "type": [
-            "null",
-            "string"
-          ]
+          "patternProperties": {
+            ".+": {}
+          }
         }
       },
       "patternProperties": {
@@ -914,6 +747,13 @@
             "string"
           ],
           "format": "date-time"
+        },
+        "completeDate": {
+          "type": [
+            "null",
+            "string"
+          ],
+          "format": "date-time"
         }
       }
     },
@@ -990,6 +830,12 @@
           ]
         },
         "accountId": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "accountType": {
           "type": [
             "null",
             "string"
@@ -1150,6 +996,12 @@
           "format": "uri"
         },
         "name": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
+        "description": {
           "type": [
             "null",
             "string"
@@ -1392,6 +1244,9 @@
           ]
         },
         "inwardIssue": {
+          "$ref": "issuestub"
+        },
+        "outwardIssue": {
           "$ref": "issuestub"
         }
       }

--- a/tap_jira/schemas/projects.json
+++ b/tap_jira/schemas/projects.json
@@ -385,6 +385,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "name": {
           "type": [
             "null",

--- a/tap_jira/schemas/users.json
+++ b/tap_jira/schemas/users.json
@@ -24,6 +24,12 @@
         "string"
       ]
     },
+    "accountType": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
     "name": {
       "type": [
         "null",

--- a/tap_jira/schemas/worklogs.json
+++ b/tap_jira/schemas/worklogs.json
@@ -149,6 +149,12 @@
             "string"
           ]
         },
+        "accountType": {
+          "type": [
+            "null",
+            "string"
+          ]
+        },
         "emailAddress": {
           "type": [
             "null",


### PR DESCRIPTION
Resolves custom fields by name, and moves any custom fields not specified in the schema to a json string stored in "_custom".

## How was this tested?
- Ran on foreground, verified that standard custom fields sprint, story points, etc. were added as expected to the schema. Verified that other fields were properly added to the _custom json. Verified that the fields___custom field in snowflake parsed as JSON and it was possible to extract the fields from it.