### PR TITLE
Add support for JWT auth

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(name="tap-jira",
       py_modules=["tap_jira"],
       install_requires=[
           "singer-python==5.4.1",
+          "atlassian-jwt==3.0.0",
           "requests==2.20.0",
       ],
       extras_require={

--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -17,17 +17,24 @@ REQUIRED_CONFIG_KEYS_CLOUD = ["start_date",
                               "refresh_token",
                               "oauth_client_id",
                               "oauth_client_secret"]
-REQUIRED_CONFIG_KEYS_HOSTED = ["start_date",
-                               "username",
-                               "password",
-                               "base_url",
-                               "user_agent"]
+REQUIRED_CONFIG_KEYS_HOSTED_PAT = ["start_date",
+                                   "username",
+                                   "password",
+                                   "base_url",
+                                   "user_agent"]
+REQUIRED_CONFIG_KEYS_HOSTED_JWT = ["start_date",
+                                   "jwt_client_key",
+                                   "jwt_shared_secret",
+                                   "base_url",
+                                   "user_agent"]
 
 
 def get_args():
     unchecked_args = utils.parse_args([])
     if 'username' in unchecked_args.config.keys():
-        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED)
+        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED_PAT)
+    elif 'jwt_client_key' in unchecked_args.config.keys():
+        return utils.parse_args(REQUIRED_CONFIG_KEYS_HOSTED_JWT)
 
     return utils.parse_args(REQUIRED_CONFIG_KEYS_CLOUD)
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -5,6 +5,7 @@ import re
 from requests.exceptions import HTTPError
 from requests.auth import HTTPBasicAuth
 import requests
+import atlassian_jwt
 from singer import metrics
 import singer
 import backoff
@@ -35,10 +36,12 @@ def should_retry_httperror(exception):
 class Client():
     def __init__(self, config):
         self.is_cloud = 'oauth_client_id' in config.keys()
+        self.jwt_config = config.get('jwt')
         self.session = requests.Session()
         self.next_request_at = datetime.now()
         self.user_agent = config.get("user_agent")
         self.login_timer = None
+        self.jwt_config = None
 
         if self.is_cloud:
             LOGGER.info("Using OAuth based API authentication")
@@ -55,6 +58,10 @@ class Client():
             # likely need to be more complicated.
             self.refresh_credentials()
             self.test_credentials_are_authorized()
+        elif self.jwt_config is not None:
+            LOGGER.info("Using JWT API authentication")
+            self.base_url = config.get("base_url")
+            self.auth = None
         else:
             LOGGER.info("Using Basic Auth API authentication")
             self.base_url = config.get("base_url")
@@ -70,7 +77,7 @@ class Client():
         base_url = 'https://' + base_url
         return base_url.rstrip("/") + "/" + path.lstrip("/")
 
-    def _headers(self, headers):
+    def _headers(self, headers, method, path):
         headers = headers.copy()
         if self.user_agent:
             headers["User-Agent"] = self.user_agent
@@ -79,8 +86,21 @@ class Client():
             # Add OAuth Headers
             headers['Accept'] = 'application/json'
             headers['Authorization'] = 'Bearer {}'.format(self.access_token)
+        elif self.jwt_config is not None:
+            # Add JWT headers
+            jwtToken = self._generateJwtToken(method, path)
+            headers['Authorization'] = 'JWT {}'.format(jwtToken)
 
         return headers
+
+    def _generateJwtToken(self, method, path):
+        return atlassian_jwt.encode_token(
+            method,
+            path,
+            self.jwt_config['client_key'],
+            self.jwt_config['shared_secret'],
+            6 * 60 * 60 # timeout in seconds = 6 hours
+        )
 
     @backoff.on_exception(backoff.expo,
                           (requests.exceptions.ConnectionError, HTTPError),
@@ -88,18 +108,18 @@ class Client():
                           max_tries=6,
                           giveup=lambda e: not should_retry_httperror(e))
     def send(self, method, path, headers={}, **kwargs):
-        if self.is_cloud:
-            # OAuth Path
+        if self.is_cloud or self.jwt_config is not None:
+            # JWT or OAuth Path
             request = requests.Request(method,
                                        self.url(path),
-                                       headers=self._headers(headers),
+                                       headers=self._headers(headers, method, path),
                                        **kwargs)
         else:
             # Basic Auth Path
             request = requests.Request(method,
                                        self.url(path),
                                        auth=self.auth,
-                                       headers=self._headers(headers),
+                                       headers=self._headers(headers, method, path),
                                        **kwargs)
         return self.session.send(request.prepare())
 


### PR DESCRIPTION
# Description of change
Add support for JWT auth, which is used when ingesting data by way of an Atlassian Connect app (such as our minware Jira app).

# Manual QA steps
- Tested locally from our `scheduled` repo to ingest a Jira site which has the minware app installed on it
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
