### PR TITLE
Add support for filtering projects

### DIFF
--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -10,6 +10,11 @@ class Context():
     stream_map = {}
 
     @classmethod
+    def get_projects(cls):
+        projectsRaw = cls.config.get("projects", "")
+        return list(map(lambda p: p.strip(), projectsRaw.split(",")))
+
+    @classmethod
     def get_catalog_entry(cls, stream_name):
         if not cls.stream_map:
             cls.stream_map = {s.tap_stream_id: s for s in cls.catalog.streams}


### PR DESCRIPTION
# Description of change
Add support for filtering projects.

https://minware.atlassian.net/browse/MW-1420

# Manual QA steps
Ran against Dynata in production and verified that the issues and projects are filtered based on the requested project filter.

Also ran against Minware without projects filter to ensure it still operates as before (no filtering).
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
