### PR TITLE
Fix string splitting problem

### DIFF
--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -13,14 +13,11 @@ class Context():
     def get_projects(cls):
         projectsRaw = cls.config.get("projects", None)
         if projectsRaw:
-            # force back to a list
-            return list(
-                # filter out empty strings
-                filter(lambda p: len(p) > 0,
-                    # convert comma-separated list into array
-                    map(lambda p: p.strip(), projectsRaw.split(","))
-                )
-            )
+            # convert comma-separated list into array
+            projectsList = list(map(lambda p: p.strip(), projectsRaw.split(",")))
+            # filter out empty strings
+            projectsList = list(filter(lambda p: len(p) > 0, projectsList))
+            return projectsList
         return []
 
     @classmethod

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -11,8 +11,17 @@ class Context():
 
     @classmethod
     def get_projects(cls):
-        projectsRaw = cls.config.get("projects", "")
-        return list(map(lambda p: p.strip(), projectsRaw.split(",")))
+        projectsRaw = cls.config.get("projects", None)
+        if projectsRaw:
+            # force back to a list
+            return list(
+                # filter out empty strings
+                filter(lambda p: len(p) > 0,
+                    # convert comma-separated list into array
+                    map(lambda p: p.strip(), projectsRaw.split(","))
+                )
+            )
+        return []
 
     @classmethod
     def get_catalog_entry(cls, stream_name):


### PR DESCRIPTION
# Description of change
Fix problem where splitting an empty string by comma results in an array with one item in it, which is apparently expected in Python.

# Manual QA steps
 - Ran Jira ingest in local environment pointing at production Snowflake for Minware (no filter) and Dynata (filter)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
