### PR TITLE
Add support for deleted worklogs

### DIFF
--- a/tap_jira/schemas/worklogs_deleted.json
+++ b/tap_jira/schemas/worklogs_deleted.json
@@ -1,0 +1,42 @@
+{
+  "title": "Worklog Deleted",
+  "type": [
+    "null",
+    "object"
+  ],
+  "properties": {
+    "worklogId": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "updatedTime": {
+      "type": [
+        "null",
+        "integer"
+      ]
+    },
+    "properties": {
+      "type": [
+        "null",
+        "array"
+      ],
+      "items": {
+        "type": [
+          "null",
+          "object"
+        ],
+        "properties": {
+          "key": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "value": {}
+        }
+      }
+    }
+  }
+}

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -368,16 +368,6 @@ class Worklogs(Stream):
 
 
 class WorklogsDeleted(Stream):
-    def _fetch_records(self, last_updated):
-        # since_ts uses millisecond precision
-        since_ts = int(last_updated.timestamp()) * 1000
-        return Context.client.request(
-            self.tap_stream_id,
-            "GET",
-            "/rest/api/2/worklog/deleted",
-            params={"since": since_ts},
-        )
-
     def sync(self):
         updated_bookmark = [self.tap_stream_id, "updated"]
         last_updated = Context.update_start_date_bookmark(updated_bookmark)

--- a/tests/spec.py
+++ b/tests/spec.py
@@ -105,4 +105,8 @@ class TapSpec():
                 self.API_LIMIT: 0, # TODO: Backlog ticket to create data required to test this documentation says 1000, see https://developer.atlassian.com/cloud/jira/platform/rest/v2/api-group-issue-worklogs/#api-rest-api-2-worklog-updated-get
                 # https://stitchdata.atlassian.net/browse/SRCE-5193
             },
+            "worklogs_deleted": {
+                self.PRIMARY_KEYS: {"worklogId"},
+                self.API_LIMIT: 0,
+            }
         }


### PR DESCRIPTION
# Description of change
https://minware.atlassian.net/browse/MW-1038

Add worklogs_deleted stream.

# Manual QA steps
Tested by running in `scheduled` against the Minware org.

Verified that 96 deleted worklog entries were populated into Snowflake (https://app.snowflake.com/us-east-2.aws/qw86304/#/data/databases/MINWARE/schemas/T_9F14E62A9A41484BB18D2967EBBA2698_JIRA/table/WORKLOGS_DELETED)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
