### PR TITLE
Only query available projects

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -142,6 +142,8 @@ class Client():
             timer.tags[metrics.Tag.http_status_code] = response.status_code
         if response.status_code == 429:
             raise RateLimitException()
+        elif response.status_code >= 400:
+            LOGGER.warn('Response text: {}'.format(response.status_code, response.text))
         response.raise_for_status()
         return response.json()
 

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -142,8 +142,8 @@ class Client():
             timer.tags[metrics.Tag.http_status_code] = response.status_code
         if response.status_code == 429:
             raise RateLimitException()
-        elif response.status_code >= 400:
-            LOGGER.warn('Response text: {}'.format(response.status_code, response.text))
+        elif response.text and response.status_code >= 400:
+            LOGGER.warn('Response body: {}'.format(response.text))
         response.raise_for_status()
         return response.json()
 


### PR DESCRIPTION

## How was this tested
 - [x] Reproduced error when project doesn't exist
 - [x] Ran with project filtering, verified with the log that only the non-existent project was available
 - [x] Ran without project filtering implemented, verified that response body was logged as a warning