### PR TITLE
Do NOT allow names for custom fields that conflict with the id of a system

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -266,7 +266,7 @@ class Issues(Stream):
             # with each other as well as system fields.
             # If we run into this problem, we append the customfields
             # numeric id to the name to avoid collisions
-            if name in fieldNames.values():
+            if name in fieldNames.values() or name in knownFields.keys():
                 name += '_' + field['id'].replace('customfield_', '')
 
             fieldNames[id] = name


### PR DESCRIPTION

## How was this tested
 - [x] Planted a `key IN ('') and ` into he JQL to fetch the problematic id
     - [x] observed error with fixVersions being the wrong schema
 - [x] Used same JQL modification as above
     - [x] Ensured fixVersions was populated with empty array that comes back directly from JIRA
     - [x] Verified `_custom` had a `fixVersions_{id}` field with the problematic version 
