### PR TITLE
Fetch all changelogs

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -89,7 +89,7 @@ def sync_sub_streams(page, issue_changelog_updated):
                         "GET",
                         "/rest/api/2/issue/{}/changelog".format(issue["id"])
                     ):
-                        for changelog in changelogs:
+                        for changelog in page:
                             if utils.strptime_to_utc(changelog["created"]) < issue_changelog_updated:
                                 fetch_more_changelogs = False
 


### PR DESCRIPTION
# Description of change
Changelogs returned with an issue can be incomplete.  This fetches all when necessary and bookmarks changelogs per project

# Manual QA steps
 - [x] Hardcoded jql to ensure I get an issue with 100+ changelogs
 - [x] Ran locally, verified all changelogs were fetched and in the outfile
 - [x] Ran with ALEXTEST org to verify state was updated properly and picked up on subsequent runs
 - [x] Inspected snowflake to verify data was in the proper format (spot checked test schema vs live schema)
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
