### PR TITLE
updating tap to allow exclude projects

### DIFF
--- a/tap_jira/__init__.py
+++ b/tap_jira/__init__.py
@@ -97,6 +97,11 @@ def sync():
     for stream in streams_.ALL_STREAMS:
         output_schema(stream)
 
+    # Fetch the list of all projects to enable exclude and per-project state
+    projectInitFetchStream = streams_.Projects("projects", ["id"])
+    projects = projectInitFetchStream.sync(True)
+    Context.set_available_projects(projects)
+
     for stream in streams_.ALL_STREAMS:
         if not Context.is_selected(stream.tap_stream_id):
             continue

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -9,17 +9,33 @@ class Context():
     catalog = None
     client = None
     stream_map = {}
+    allProjectsList = []
 
     @classmethod
     def get_projects(cls):
         projectsRaw = cls.config.get("projects", None)
+        excludeProjects = cls.config.get("exclude_projects", None)
         if projectsRaw:
             # convert comma-separated list into array
             projectsList = list(map(lambda p: p.strip(), projectsRaw.split(",")))
             # filter out empty strings
             projectsList = list(filter(lambda p: len(p) > 0, projectsList))
             return projectsList
-        return []
+        elif excludeProjects:
+            # convert comma-separated list into array
+            excludeProjectsList = list(map(lambda p: p.strip(), excludeProjects.split(",")))
+            # filter out empty strings
+            excludeProjectsList = list(filter(lambda p: len(p) > 0, excludeProjectsList))
+            return list(set(cls.allProjectsList) - set(excludeProjectsList))
+        else:
+            return cls.allProjectsList
+
+    @classmethod
+    def set_available_projects(cls, projectList):
+        projectKeys = []
+        for project in projectList:
+            projectKeys.append(project["key"])
+        cls.allProjectsList = projectKeys
 
     @classmethod
     def get_catalog_entry(cls, stream_name):


### PR DESCRIPTION
# How was this tested?
 - Ran in on-premise-agent with all, include, and exclude. Verified correct data and state output for each mode.
 - Tested including project that doesn't exist to verify it is handled and logged properly.