### PR TITLE
Update state to avoid problematic timeframe, fetch all changelogs and dont rely on order

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -75,21 +75,14 @@ def sync_sub_streams(page, issue_changelog_updated):
                 for changelog in changelogs:
                     changelogs_to_write.append(changelog)
             else:
-                pager = Paginator(Context.client, order_by="sequence")
-                fetch_more_changelogs = True
+                pager = Paginator(Context.client)
                 for page in pager.pages(
                     CHANGELOGS.tap_stream_id,
                     "GET",
                     "/rest/api/2/issue/{}/changelog".format(issue["id"])
                 ):
                     for changelog in page:
-                        if utils.strptime_to_utc(changelog["created"]) < issue_changelog_updated:
-                            fetch_more_changelogs = False
-
                         changelogs_to_write.append(changelog)
-
-                    if not fetch_more_changelogs:
-                        break
 
             CHANGELOGS.write_page(
                 [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
@@ -373,12 +366,18 @@ class Issues(Stream):
         last_updated = Context.update_start_date_bookmark(updated_bookmark)
         timezone = Context.retrieve_timezone()
         start_date = last_updated.astimezone(pytz.timezone(timezone)).strftime("%Y-%m-%d %H:%M")
-        if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < last_updated < datetime.datetime(2024, 7, 23, 5, 0, 0, tzinfo=pytz.utc):
+        if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < last_updated < datetime.datetime(2024, 8, 10, 5, 0, 0, tzinfo=pytz.utc):
             LOGGER.info('state is in broken timeframe, going back in time to ensure all issues are ingested')
             start_date = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc).strftime("%Y-%m-%d %H:%M")
 
         issue_changelogs_updated_bookmark_path = [CHANGELOGS.tap_stream_id, project_key_or_id, "updated"]
         issue_changelogs_updated = Context.update_start_date_bookmark(issue_changelogs_updated_bookmark_path)
+        LOGGER.info('changelog updated state {}'.format(issue_changelogs_updated))
+        if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < issue_changelogs_updated < datetime.datetime(2024, 8, 10, 5, 0, 0, tzinfo=pytz.utc):
+            LOGGER.info('changelog state is in broken timeframe, going back in time to ensure all issues are ingested')
+            start_date = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc).strftime("%Y-%m-%d %H:%M")
+            issue_changelogs_updated = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc)
+
         # grab the time now, before we sync any changelogs
         # this will be used later to bookmark our progress
         # there will be some overlap during the sync, but this allows us to avoid saving state per issue

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -372,7 +372,6 @@ class Issues(Stream):
 
         issue_changelogs_updated_bookmark_path = [CHANGELOGS.tap_stream_id, project_key_or_id, "updated"]
         issue_changelogs_updated = Context.update_start_date_bookmark(issue_changelogs_updated_bookmark_path)
-        LOGGER.info('changelog updated state {}'.format(issue_changelogs_updated))
         if datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc) < issue_changelogs_updated < datetime.datetime(2024, 8, 10, 5, 0, 0, tzinfo=pytz.utc):
             LOGGER.info('changelog state is in broken timeframe, going back in time to ensure all issues are ingested')
             start_date = datetime.datetime(2024, 7, 15, 0, 0, tzinfo=pytz.utc).strftime("%Y-%m-%d %H:%M")


### PR DESCRIPTION
# Description of change
Stop relying on the order of the changelogs returned by JIRA.  The orderBy param does not work for that endpoint.  We must fetch all of them when necessary.

# Manual QA steps
 - [x] Ran locally with a subset of issues
 - [x] **Before Merge** run against minware (full run) to verify all changelogs are retrieved
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
