### PR TITLE
Alex/2024 09 09 mw 4024 support exclude issue fields

### DIFF
--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -94,5 +94,5 @@ class Context():
         return response.json()["timeZone"]
 
     @classmethod
-    def get_excluded_fields(cls):
-        return cls.config.get("excluded_fields", [])
+    def get_exclude_issue_fields(cls):
+        return [str(x) for x in cls.config.get("exclude_issue_fields", [])]

--- a/tap_jira/context.py
+++ b/tap_jira/context.py
@@ -92,3 +92,7 @@ class Context():
         response = cls.client.send("GET", "/rest/api/2/myself")
         response.raise_for_status()
         return response.json()["timeZone"]
+
+    @classmethod
+    def get_excluded_fields(cls):
+        return cls.config.get("excluded_fields", [])

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -101,8 +101,15 @@ def sync_sub_streams(page, issue_changelog_updated):
                 changelog_items = []
                 for item in changelog['items']:
                     if 'fieldId' in item and should_exclude_field(item['fieldId'], item['field']):
-                        continue
-
+                        if item['from'] is not None:
+                            item['from'] = '<REDACTED>'
+                        if item['fromString'] is not None:
+                            item['fromString'] = '<REDACTED>'
+                        if item['to'] is not None:
+                            item['to'] = '<REDACTED>'
+                        if item['toString'] is not None:
+                            item['toString'] = '<REDACTED>'
+                        
                     changelog_items.append(item)
                 changelog['items'] = changelog_items
 
@@ -434,7 +441,6 @@ class Issues(Stream):
 
                 # Rename all of the custom fields
                 # filter excluded fields
-                excluded_fields = Context.get_exclude_issue_fields()
                 for k in list(issue['fields'].keys()):
                     if k[:len('customfield_')] == 'customfield_':
                         val = issue['fields'][k]
@@ -443,7 +449,7 @@ class Issues(Stream):
 
                     if fieldNames[k] in issue['fields'] and should_exclude_field(k, fieldNames[k]):
                         LOGGER.debug('Excluding field {} - {}'.format(k, fieldNames[k]))
-                        del issue['fields'][fieldNames[k]]
+                        issue['fields'][fieldNames[k]] = '<REDACTED>'
 
                 # Now, go through and separate fields we don't recognize into "_custom"
                 customFields = {}

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -101,13 +101,13 @@ def sync_sub_streams(page, issue_changelog_updated):
                 changelog_items = []
                 for item in changelog['items']:
                     if 'fieldId' in item and should_exclude_field(item['fieldId'], item['field']):
-                        if item['from'] is not None:
+                        if item['from'] is not None and item['from'] != '':
                             item['from'] = '<REDACTED>'
-                        if item['fromString'] is not None:
+                        if item['fromString'] is not None and item['fromString'] != '':
                             item['fromString'] = '<REDACTED>'
-                        if item['to'] is not None:
+                        if item['to'] is not None and item['to'] != '':
                             item['to'] = '<REDACTED>'
-                        if item['toString'] is not None:
+                        if item['toString'] is not None and item['toString'] != '':
                             item['toString'] = '<REDACTED>'
                         
                     changelog_items.append(item)

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -410,6 +410,11 @@ class Issues(Stream):
                 # so we decided to just strip the field out for now.
                 issue['fields'].pop('operations', None)
 
+                excluded_fields = Context.get_excluded_fields()
+                for k, v in issue['fields'].items():
+                    if k in excluded_fields or v['id'] in excluded_fields:
+                        del issue['fields'][k]
+                    
                 # Rename all of the custom fields
                 for k in list(issue['fields'].keys()):
                     if k[:len('customfield_')] == 'customfield_':

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -57,6 +57,18 @@ def raise_if_bookmark_cannot_advance(worklogs):
                         .format(worklog_updatedes[0]))
 
 
+def should_exclude_field(field_id, field_name):
+    excluded_fields = Context.get_exclude_issue_fields()
+    if field_id in excluded_fields:
+        return True
+    
+    if field_id.startswith('customfield_'):
+        custom_field_id = field_id[len('customfield_'):]
+        if field_name.rstrip('_' + custom_field_id) in excluded_fields: 
+            return True
+    
+    return False
+
 def sync_sub_streams(page, issue_changelog_updated):
     for issue in page:
         comments = issue["fields"].pop("comment")["comments"]
@@ -83,6 +95,16 @@ def sync_sub_streams(page, issue_changelog_updated):
                 ):
                     for changelog in page:
                         changelogs_to_write.append(changelog)
+
+
+            for changelog in changelogs_to_write:
+                changelog_items = []
+                for item in changelog['items']:
+                    if 'fieldId' in item and should_exclude_field(item['fieldId'], item['field']):
+                        continue
+
+                    changelog_items.append(item)
+                changelog['items'] = changelog_items
 
             CHANGELOGS.write_page(
                 [{ **changelog, 'issueId': issue["id"] } for changelog in changelogs_to_write]
@@ -410,17 +432,18 @@ class Issues(Stream):
                 # so we decided to just strip the field out for now.
                 issue['fields'].pop('operations', None)
 
-                excluded_fields = Context.get_excluded_fields()
-                for k, v in issue['fields'].items():
-                    if k in excluded_fields or v['id'] in excluded_fields:
-                        del issue['fields'][k]
-                    
                 # Rename all of the custom fields
+                # filter excluded fields
+                excluded_fields = Context.get_exclude_issue_fields()
                 for k in list(issue['fields'].keys()):
                     if k[:len('customfield_')] == 'customfield_':
                         val = issue['fields'][k]
                         del issue['fields'][k]
                         issue['fields'][fieldNames[k]] = val
+
+                    if fieldNames[k] in issue['fields'] and should_exclude_field(k, fieldNames[k]):
+                        LOGGER.debug('Excluding field {} - {}'.format(k, fieldNames[k]))
+                        del issue['fields'][fieldNames[k]]
 
                 # Now, go through and separate fields we don't recognize into "_custom"
                 customFields = {}


### PR DESCRIPTION
# Description of change
Add configuration to exclude issue fields. It will remove those fields from the issues themselves as well as remove any changelog items that reference that particular field.

# Manual QA steps
 - [x] Ran with field excluded, verified records did not include fields in output
 - [x] Ran without exclude_issue_fields option and verified all fields were present in output
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
