### PR TITLE
Myles/mw 5130 updates

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -111,7 +111,6 @@ class Client():
         (requests.exceptions.ConnectionError, HTTPError),
         jitter=None,
         max_tries=6,
-        max_time=600,
         giveup=lambda e: not should_retry_httperror(e)
     )
     def send(self, method, path, headers={}, **kwargs):

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -106,13 +106,11 @@ class Client():
             6 * 60 * 60 # timeout in seconds = 6 hours
         )
 
-    @backoff.on_exception(
-        backoff.expo,
-        (requests.exceptions.ConnectionError, HTTPError),
-        jitter=None,
-        max_tries=6,
-        giveup=lambda e: not should_retry_httperror(e)
-    )
+    @backoff.on_exception(backoff.expo,
+                          (requests.exceptions.ConnectionError, HTTPError),
+                          jitter=None,
+                          max_tries=6,
+                          giveup=lambda e: not should_retry_httperror(e))
     def send(self, method, path, headers={}, **kwargs):
         if self.is_cloud or self.jwt_client_key is not None:
             # JWT or OAuth Path

--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -106,11 +106,14 @@ class Client():
             6 * 60 * 60 # timeout in seconds = 6 hours
         )
 
-    @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError, HTTPError),
-                          jitter=None,
-                          max_tries=6,
-                          giveup=lambda e: not should_retry_httperror(e))
+    @backoff.on_exception(
+        backoff.expo,
+        (requests.exceptions.ConnectionError, HTTPError),
+        jitter=None,
+        max_tries=6,
+        max_time=600,
+        giveup=lambda e: not should_retry_httperror(e)
+    )
     def send(self, method, path, headers={}, **kwargs):
         if self.is_cloud or self.jwt_client_key is not None:
             # JWT or OAuth Path

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -349,7 +349,6 @@ class Issues(Stream):
                 # bubble up any exceptions discovered while syncing a project
                 try:
                     for future in as_completed(func_call_futures):
-                        # result() will raise any exception from that thread
                         future.result()
                 except Exception as ex:
                     LOGGER.error(
@@ -481,11 +480,10 @@ class Issues(Stream):
             LOGGER.info("Writing issues for page %d, project %s...", page_index, project_key_or_id)
             with self.write_lock:
                 self.write_page(page)
-                # store offset and state
+
                 Context.set_bookmark(page_num_offset, pager.next_page_num)
                 singer.write_state(Context.state)
             
-            # <--- new log
             LOGGER.info("Finished writing issues for page %d, project %s", page_index, project_key_or_id)
             page_index += 1
         

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -351,7 +351,7 @@ class Issues(Stream):
                     for func_call_future in func_call_futures:
                         func_call_future.result()
                 except Exception as ex:
-                    LOGGER.error("Issues.sync encountered an error in a thread: %s", exc)
+                    LOGGER.error("Issues.sync encountered an error in a thread: %s", ex)
                     raise ex
 
         self.delete_old_state()

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -11,7 +11,7 @@ from singer import metrics, utils, metadata, Transformer, Timer
 from .http import Paginator
 from .context import Context
 from itertools import chain
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from minware_singer_utils import SecureLogger
 
@@ -346,12 +346,15 @@ class Issues(Stream):
                     func_call = functools.partial(ctx.run, self.sync_project, fieldNames, knownFields, project_key_or_id)
                     func_call_futures.append(executor.submit(func_call))
 
-                ## bubble up any exceptions discovered while syncing a project
+                # bubble up any exceptions discovered while syncing a project
                 try:
-                    for func_call_future in func_call_futures:
-                        func_call_future.result()
+                    for future in as_completed(func_call_futures):
+                        # result() will raise any exception from that thread
+                        future.result()
                 except Exception as ex:
-                    LOGGER.error("Issues.sync encountered an error in a thread: %s", ex)
+                    LOGGER.error(
+                        "Issues.sync encountered an error in a thread: %s", ex
+                    )
                     raise ex
 
         self.delete_old_state()

--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -351,7 +351,8 @@ class Issues(Stream):
                     for func_call_future in func_call_futures:
                         func_call_future.result()
                 except Exception as ex:
-                    LOGGER.exception(ex)
+                    LOGGER.error("Issues.sync encountered an error in a thread: %s", exc)
+                    raise ex
 
         self.delete_old_state()
 
@@ -381,7 +382,7 @@ class Issues(Stream):
         if project_key_or_id is None:
             project_key_or_id = self.ALL_PROJECTS_BOOKMARK_KEY
 
-        LOGGER.info('syncing issues for project {}'.format(project_key_or_id))
+        LOGGER.info('Begin syncing issues for project {}'.format(project_key_or_id))
 
         # build projects filter from config, if any
         projectsJql = "" if project_key_or_id == self.ALL_PROJECTS_BOOKMARK_KEY \
@@ -422,9 +423,16 @@ class Issues(Stream):
                   "jql": jql}
         page_num = Context.bookmark(page_num_offset) or 0
         pager = Paginator(Context.client, items_key="issues", page_num=page_num)
+
+        page_index = 0
         for page in pager.pages(self.tap_stream_id,
                                 "GET", "/rest/api/2/search",
                                 params=params):
+
+            LOGGER.info(
+                "Fetched page %d with %d issues for project %s",
+                page_index, len(page), project_key_or_id
+            )
             # sync comments and changelogs for each issue
             sync_sub_streams(page, issue_changelogs_updated)
             for issue in page:
@@ -467,16 +475,25 @@ class Issues(Stream):
 
             # Grab last_updated before transform in write_page
             last_updated = utils.strptime_to_utc(page[-1]["fields"]["updated"])
+            LOGGER.info("Writing issues for page %d, project %s...", page_index, project_key_or_id)
             with self.write_lock:
                 self.write_page(page)
-
+                # store offset and state
                 Context.set_bookmark(page_num_offset, pager.next_page_num)
                 singer.write_state(Context.state)
+            
+            # <--- new log
+            LOGGER.info("Finished writing issues for page %d, project %s", page_index, project_key_or_id)
+            page_index += 1
+        
+        # After the loop completes
         with self.write_lock:
             Context.set_bookmark(page_num_offset, None)
             Context.set_bookmark(updated_bookmark, last_updated)
             Context.set_bookmark(issue_changelogs_updated_bookmark_path, issue_changelogs_sync_time)
             singer.write_state(Context.state)
+
+        LOGGER.info('Done syncing project %s', project_key_or_id)
 
 
 class Worklogs(Stream):


### PR DESCRIPTION
THis is an attempt to get more information when we do run into issues around silent failures in tap-jira.

1. Add extra logging 
2. Use the as_completed function to process results from threads as they are completed rather than waiting until after all are completed.
3. Throw exceptions rather than just logging them

I've ran this tap against an org using their production state and watched it run to completion.