### PR TITLE
fix bug

### DIFF
--- a/tap_jira/streams.py
+++ b/tap_jira/streams.py
@@ -180,13 +180,13 @@ def sync_sub_streams(page, issue_changelog_updated, changelog_map=None):
                 changelog_items = []
                 for item in changelog['items']:
                     if 'fieldId' in item and should_exclude_field(item['fieldId'], item['field']):
-                        if item['from'] is not None and item['from'] != '':
+                        if 'from' in item and item['from'] is not None and item['from'] != '':
                             item['from'] = '<REDACTED>'
-                        if item['fromString'] is not None and item['fromString'] != '':
+                        if 'fromString' in item and item['fromString'] is not None and item['fromString'] != '':
                             item['fromString'] = '<REDACTED>'
-                        if item['to'] is not None and item['to'] != '':
+                        if 'to' in item and item['to'] is not None and item['to'] != '':
                             item['to'] = '<REDACTED>'
-                        if item['toString'] is not None and item['toString'] != '':
+                        if 'toString' in item and item['toString'] is not None and item['toString'] != '':
                             item['toString'] = '<REDACTED>'
                         
                     changelog_items.append(item)


### PR DESCRIPTION
Check if from/to exist before accessing. 

Validated by running an ingest for an org that has excluded fields in the config and confirming that we get <REDACTED> in the changelogs from/to and issues custom fields.