### PR TITLE
retry ChunkedEncodingErrors

### DIFF
--- a/tap_jira/http.py
+++ b/tap_jira/http.py
@@ -119,7 +119,7 @@ class Client():
         )
 
     @backoff.on_exception(backoff.expo,
-                          (requests.exceptions.ConnectionError, HTTPError),
+                          (requests.exceptions.ConnectionError, requests.exceptions.ChunkedEncodingError, HTTPError),
                           jitter=None,
                           max_tries=6,
                           giveup=lambda e: not should_retry_httperror(e))


### PR DESCRIPTION
# Description of change
Adds requests.exceptions.ChunkedEncodingError to the list of errors that we will retry. While it seems to wrap a connectionError, it's not one of the explicitly retried errors.

This is an effort to handle situations like this:
```
ERROR Project XXXXX: Encountered an error: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
ERROR A project sync failed with an unhandled error: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
CRITICAL ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
Traceback (most recent call last):
  File "/opt/tap-jira/lib/python3.9/site-packages/urllib3/response.py", line 362, in _error_catcher
    yield
  File "/opt/tap-jira/lib/python3.9/site-packages/urllib3/response.py", line 668, in read_chunked
    self._update_chunk_length()
  File "/opt/tap-jira/lib/python3.9/site-packages/urllib3/response.py", line 600, in _update_chunk_length
    line = self._fp.fp.readline()
  File "/usr/local/lib/python3.9/socket.py", line 716, in readinto
    return self._sock.recv_into(b)
  File "/usr/local/lib/python3.9/ssl.py", line 1275, in recv_into
    return self.read(nbytes, buffer)
  File "/usr/local/lib/python3.9/ssl.py", line 1133, in read
    return self._sslobj.read(len, buffer)
ConnectionResetError: [Errno 104] Connection reset by peer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/tap-jira/lib/python3.9/site-packages/requests/models.py", line 750, in generate
    for chunk in self.raw.stream(chunk_size, decode_content=True):
  File "/opt/tap-jira/lib/python3.9/site-packages/urllib3/response.py", line 492, in stream
    for line in self.read_chunked(amt, decode_content=decode_content):
  File "/opt/tap-jira/lib/python3.9/site-packages/urllib3/response.py", line 696, in read_chunked
    self._original_response.close()
  File "/usr/local/lib/python3.9/contextlib.py", line 137, in __exit__
    self.gen.throw(typ, value, traceback)
  File "/opt/tap-jira/lib/python3.9/site-packages/urllib3/response.py", line 380, in _error_catcher
    raise ProtocolError('Connection broken: %r' % e, e)
urllib3.exceptions.ProtocolError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/tap-jira/bin/tap-jira", line 8, in <module>
    sys.exit(main())
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/__init__.py", line 162, in main
    raise exc
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/__init__.py", line 159, in main
    main_impl()
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/__init__.py", line 152, in main_impl
    sync()
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/__init__.py", line 129, in sync
    stream.sync()
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/streams.py", line 481, in sync
    raise exc
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/streams.py", line 470, in sync
    result = self._sync_project_with_error_handling(fieldNames, knownFields, project_key_or_id)
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/streams.py", line 546, in _sync_project_with_error_handling
    raise exc
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/streams.py", line 528, in _sync_project_with_error_handling
    self.sync_project(fieldNames, knownFields, project_key_or_id)
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/streams.py", line 596, in sync_project
    for id_page in id_pager.pages(self.tap_stream_id, jql):
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/http.py", line 399, in pages
    response = self.client.request(
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/http.py", line 153, in request
    response = self.send(*args, **kwargs)
  File "/opt/tap-jira/lib/python3.9/site-packages/backoff/_sync.py", line 94, in retry
    ret = target(*args, **kwargs)
  File "/opt/tap-jira/lib/python3.9/site-packages/tap_jira/http.py", line 140, in send
    return self.session.send(request.prepare())
  File "/opt/tap-jira/lib/python3.9/site-packages/requests/sessions.py", line 677, in send
    r.content
  File "/opt/tap-jira/lib/python3.9/site-packages/requests/models.py", line 828, in content
    self._content = b''.join(self.iter_content(CONTENT_CHUNK_SIZE)) or b''
  File "/opt/tap-jira/lib/python3.9/site-packages/requests/models.py", line 753, in generate
    raise ChunkedEncodingError(e)
requests.exceptions.ChunkedEncodingError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
```
  
# Rollback steps
 - revert this branch
