### PR TITLE
Pin PyJWT <2.12.1 to fix Jira ingest failures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(name="tap-jira",
       install_requires=[
           "singer-python==5.12.1",
           "atlassian-jwt==3.0.0",
+          "PyJWT>=2.2.0,<2.12.1",
           "requests==2.20.0",
           "psutil>=5.9.0",
           'minware_singer_utils@git+https://{}github.com/minwareco/minware-singer-utils.git@{}'.format(


### PR DESCRIPTION
## Summary
- Pin `PyJWT>=2.2.0,<2.12.1` in setup.py to prevent pip from pulling PyJWT 2.12.1, which requires `typing_extensions` on Python <3.11
- Fixes MW-10972: all 191 Jira ingest jobs across 32 orgs were failing with `ModuleNotFoundError: No module named 'typing_extensions'`

## Root cause
`atlassian-jwt==3.0.0` declares `PyJWT>=2.2.0` with no upper bound. PyJWT 2.12.1 added `typing_extensions>=4.0` as a dependency for Python <3.11, but it wasn't being installed as a transitive dep in the Docker build. Since our executor image uses Python 3.9, every fresh build pulls the broken version.

## Test plan
- [x] Dev ingest for tap-jira to verify that it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)