### PR TITLE
Pin PyJWT <2.11.0 to fix Jira ingest failures (MW-10972)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(name="tap-jira",
       install_requires=[
           "singer-python==5.12.1",
           "atlassian-jwt==3.0.0",
-          "PyJWT>=2.2.0,<2.12.1",
+          "PyJWT>=2.2.0,<2.11.0",
           "requests==2.20.0",
           "psutil>=5.9.0",
           'minware_singer_utils@git+https://{}github.com/minwareco/minware-singer-utils.git@{}'.format(


### PR DESCRIPTION
## Summary
- Pins `PyJWT>=2.2.0,<2.11.0` in setup.py to prevent pip from resolving versions that use `typing_extensions` without declaring it as a dependency
- Fixes MW-10972: Jira ingest jobs failing with `ModuleNotFoundError: No module named 'typing_extensions'` on Python 3.9

## Context
The previous fix (https://github.com/minwareco/tap-jira/pull/39) pinned `<2.12.1`, but PyJWT 2.11.0 and 2.12.0 also import `typing_extensions` without declaring it. 2.10.1 is the last version without any `typing_extensions` usage.

## Test plan
- [ ] Test in prod after updating scheduled. I test the previous change locally and it worked but didn't work in prod... 🤯

🤖 Generated with [Claude Code](https://claude.com/claude-code)